### PR TITLE
Trigger rule according to author

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ A Basic Configuration must define:
 
 1. The site string. e.g. `example.com`
 	* Use the same configuration for multiple URL's by seperating them with the `|` Delimiter. e.g. `"example.com|example.net"`
+	* The attached config will be applied when the site string matches the `<link>` or `<author>` tag of the feed item.
 2. The Filter type. e.g. `"type":"xpath"`
 3. The Filter config. e.g. `"xpath":"div[@id='content']"` or the array `"xpath": [ "div[@id='article']", "div[@id='footer']"]`
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ A Basic Configuration must define:
 
 1. The site string. e.g. `example.com`
 	* Use the same configuration for multiple URL's by seperating them with the `|` Delimiter. e.g. `"example.com|example.net"`
-	* The attached config will be applied when the site string matches the `<link>` or `<author>` tag of the feed item.
+	* The configuration will be applied when the site string matches the `<link>` or `<author>` tag of the RSS feed item.
+		* The `<link>` takes precedence over the `<author>`
+		* `<author>` based configurations will **NOT** automatically show in the Testing Tab
 2. The Filter type. e.g. `"type":"xpath"`
 3. The Filter config. e.g. `"xpath":"div[@id='content']"` or the array `"xpath": [ "div[@id='article']", "div[@id='footer']"]`
 

--- a/init.php
+++ b/init.php
@@ -356,10 +356,16 @@ class Feediron extends Plugin implements IHandler
 	function getHtmlNode($node){
 		if (is_object($node)){
 			$newdoc = new DOMDocument();
-			$cloned = $node->cloneNode(TRUE);
-			$newdoc->appendChild($newdoc->importNode($cloned,TRUE));
+			if ($node->nodeType == XML_ATTRIBUTE_NODE) {
+				// appendChild will fail, so make it a text node
+				$imported = $newdoc->createTextNode($node->value);
+			} else {
+				$cloned = $node->cloneNode(TRUE);
+				$imported = $newdoc->importNode($cloned,TRUE);
+			}
+			$newdoc->appendChild($imported);
 			return $newdoc->saveHTML();
-		}else{
+		} else {
 			return $node;
 		}
 	}

--- a/init.php
+++ b/init.php
@@ -73,7 +73,15 @@ class Feediron extends Plugin implements IHandler
 	function hook_article_filter($article)
 	{
 		Feediron_Logger::get()->set_log_level(0);
-		if (($config = $this->getConfigSection($article['link'])) !== FALSE)
+		$link = $article["link"];
+		if ($link === null) {
+			return $article;
+		};
+		$config = $this->getConfigSection($link);
+		if ($config === FALSE) {
+			$config = $this->getConfigSection($article['author']);
+		}
+		if ($config !== FALSE)
 		{
 			if (version_compare(VERSION, '1.14.0', '<=')){
 				if (strpos($article['plugin_data'], $articleMarker) !== false)
@@ -81,11 +89,11 @@ class Feediron extends Plugin implements IHandler
 					return $article;
 				}
 
-				Feediron_Logger::get()->log(Feediron_Logger::LOG_TTRSS, "Article was not fetched yet: ".$article['link']);
+				Feediron_Logger::get()->log(Feediron_Logger::LOG_TTRSS, "Article was not fetched yet: ".$link);
 				$article['plugin_data'] = $this->addArticleMarker($article, $articleMarker);
 			}
-			$link = $this->reformatUrl($article['link'], $config);
-			$article['content'] = $this->getNewContent($link, $config);
+			$newlink = $this->reformatUrl($link, $config);
+			$article['content'] = $this->getNewContent($newlink, $config);
 
 		}
 
@@ -106,6 +114,7 @@ class Feediron extends Plugin implements IHandler
 
 	function getConfigSection($url)
 	{
+		if ($url === null) { return FALSE; };
 		$data = $this->getConfig();
 		if(is_array($data)){
 

--- a/recipes/hiveworks
+++ b/recipes/hiveworks
@@ -1,0 +1,16 @@
+{
+    "name": "tech@thehiveworks.com",
+    "url": "tech@thehiveworks.com",
+    "stamp": 1532615549,
+    "author": "",
+    "match": "tech@thehiveworks.com",
+    "config": {
+        "type": "xpath",
+        "xpath": [
+            "img[@id='cc-comic']",
+            "img[@id='cc-comic']\/@title",
+            "div[@class='cc-newsbody']"
+        ],
+        "join_element": "<br\/>"
+    }
+}


### PR DESCRIPTION
First commit:

I wanted a rule for RSS feeds authored by sites belonging to the hiveworks network. They have in common the author field of the feed. Unfortunately, I cannot write a single rule for them because they have completely unrelated domains.

This makes feediron trigger a rule if the key in the config matches the author feed, and not only the url.
I also added the corresponding recipe.

Second commit: (The two commits could be split in two PRs if you insist by the way.)

I ran into #73 while using this recipe: xpath can select an attribute node, which is refused by appendChild. This commit replaces it by a text node.
I have ran this for more than a week without problems, now.

Please review carefully, I don't speak PHP.
