### PR TITLE
replace continue in switch statement with break

### DIFF
--- a/init.php
+++ b/init.php
@@ -495,7 +495,7 @@ class Feediron extends Plugin implements IHandler
 
 			default:
 			Feediron_Logger::get()->log(Feediron_Logger::LOG_TTRSS, "Unrecognized option: ".$config['type']);
-			continue;
+			break;
 		}
 		if(is_array($config['modify']))
 		{


### PR DESCRIPTION
php throws the following warning:
```
`continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?
```
continue doesn't make sense anyway as there is no loop to continue.

Please answer the following questions for yourself before submitting a pull request. **YOU MAY DELETE UNUSED SECTIONS.**
# Bugfix/Enhancement

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?