### PR TITLE
Fix for linked images at xkcd

### DIFF
--- a/recipes/xkcd_com
+++ b/recipes/xkcd_com
@@ -1,15 +1,14 @@
 {
     "name": "xkcd.com",
     "url": "xkcd.com",
-    "stamp": 1424070543,
     "author": "Matthias Bilger",
     "match": "xkcd.com",
     "config": {
         "type": "xpath",
         "xpath": [
             "div[contains(@id,'comic')]",
-            "div[contains(@id,'comic')]\/img\/@title"
+            "div[contains(@id,'comic')]\/\/img\/@title"
         ],
-        "join_element": "<p \/>"
+        "join_element": "<p>"
    }
 }


### PR DESCRIPTION
# Rule Submission
Website: xkcd.com

* [x] I have made the rule as simple as possible ( K.I.S.S )
* [x] I have run the rule myself for a period of time to spot any bugs

## Proposed Changes
- Support for linked images as in the comic from 2019-02-27: https://xkcd.com/2116