### PR TITLE
Fix missing last page when using multipage

### DIFF
--- a/init.php
+++ b/init.php
@@ -500,7 +500,7 @@ class Feediron extends Plugin implements IHandler
     if (count(array_intersect($seenlinks, $links)) != 0)
     {
       Feediron_Logger::get()->log_object(Feediron_Logger::LOG_VERBOSE, "Break infinite loop for recursive multipage, link intersection",array_intersect($seenlinks, $links));
-      return array();
+      return array($link);
     }
     foreach ($links as $lnk)
     {


### PR DESCRIPTION
In the specific case where fetching more pages is stopped due to finding
a duplicate link, the link to the page where the duplicate found was not
being returned.

This manifested as the last page of a multipage article not being
processed.

This commit fixes this by returning an array with the current link in it
when finding a duplicate link.