### PR TITLE
Update Arstechnica recipe to include image galleries

### DIFF
--- a/recipes/arstechnica
+++ b/recipes/arstechnica
@@ -6,19 +6,22 @@
     "match": "arstechnica.com",
     "config": {
         "type": "xpath",
+        "xpath": "div[contains(@class, 'article-content')]",
         "multipage": {
-            "xpath": "span[@class='numbers']\/a",
+            "xpath": "nav[contains(@class, 'page-numbers')]\/span\/a[last()]",
             "append": true,
             "recursive": true
         },
-        "xpath": [
-            "section[@class='article-guts']"
+        "modify": [
+            {
+                "type": "regex",
+                "pattern": "\/<li.*? data-src=\"(.*?)\".*?>\\s*<figure.*?>.*?(?:<figcaption.*?<div class=\"caption\">(.*?)<\\\/div>.*?<\\\/figcaption>)?\\s*<\\\/figure>\\s*<\\\/li>\/s",
+                "replace": "<figure><img src=\"$1\"\/><figcaption>$2<\/figcaption><\/figure>"
+            }
         ],
         "cleanup": [
-            "figcaption",
             "aside",
-            "div[@class='article-expander']",
-            "nav"
+            "div[contains(@class, 'sidebar')]"
         ]
     }
 }


### PR DESCRIPTION
# Rule Submission

Website: arstechnica.com

* [x] I have made the rule as simple as possible ( K.I.S.S )
* [x] I have run the rule myself for a period of time (1 month+) to spot any bugs

The regex is a bit ugly but does the job. Here's what an image gallery looks like in HTML (cleaned up a bit, placeholder text in `[]`'s)

```html
<ul>
    <li data-thumb="[tiny image url]" data-src="[fullsize image url]" data-responsive="[list of image urls followed by sizes]" data-sub-html="#caption-[caption id]">
        <figure style="height:[something]px;">
            <div class="image" style="background-image:url('[midsize image url]'); background-color:#000"></div>
            <figcaption id="caption-[caption id]">
                <span class="icon caption-arrow icon-drop-indicator"></span>
                <div class="caption">[some caption]</div>
                <div class="credit"><span class="icon icon-camera"></span>[some person]</div>
            </figcaption>
        </figure>
    </li>
    [many more <li></li>'s]
</ul>
```

The regex aims to pull out `[fullsize image url]` and `[some caption]` and convert them into the following format:
```html
<figure><img src="[fullsize image url]"/><figcaption>[some caption]</figcaption></figure>
```

The regex explained:
```regex
<li.*? data-src="(.*?)".*?>             # match '<li [other attrs] data-src="url" [other attrs]>' and store the URL
\s*<figure.*?>.*?(?:<figcaption         # match the <figure><figcaption> tags
.*?<div class="caption">(.*?)</div>     # match the caption div and store the text inside it
.*?</figcaption>)?\s*</figure>\s*</li>  # match all the closing tags to reduce false positives
```
Notes:
 - The `?` after the patterns signifies a non-greedy match so the regex will attempt to match as little text as possible.
 - The `(?:<figcaption>[other stuff]</figcaption>)?` part is an optional, non-capturing group. This means that if there is no caption the regex at least still matches the image url. Being non-capturing just means that it won't be made available in the replace phase.