### PR TITLE
[Bug correction] Reset basenode at each xpath rule

### DIFF
--- a/init.php
+++ b/init.php
@@ -841,7 +841,6 @@ class Feediron extends Plugin implements IHandler
     function performXpath($html, $config)
     {
       $doc = $this->getDOM($html);
-      $basenode = false;
       $xpathdom = new DOMXPath($doc);
 
       if(!is_array($config['xpath'])){
@@ -861,6 +860,7 @@ class Feediron extends Plugin implements IHandler
         }
         $entries = $xpathdom->query('(//'.$xpath.')');   // find main DIV according to config
 
+          $basenode = false;
           if ($entries->length > 0) {
             $basenode = $entries->item($index);
           }


### PR DESCRIPTION
When a xpath ruleset is made of several rules, and, for instance, the second rule return a void (because the underlying website as an optional HTML node for example), then the $basenode value will be filled with the node returned by the first rule of the set.
So, to correct this and avoid repetitions into the result, the basenode=false have to be inside the rule's loop.

# Bugfix/Enhancement
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?

# Example
Website: http://secouchermoinsbete.fr/
ATOM: https://secouchermoinsbete.fr/feeds.atom
Rule:
~~~json
    "secouchermoinsbete.fr": {
        "type": "xpath",
        "xpath": [
            "article[@class='anecdote']\/p[@class='summary']",
            "article[@class='anecdote']\/p[@class='details']",
            "div[@id='sources']"
        ],
        "join_element": "<br><br>"
    }
~~~
