### PR TITLE
add hackaday.com recipe

### DIFF
--- a/recipes/hackaday.com
+++ b/recipes/hackaday.com
@@ -1,0 +1,13 @@
+{
+    "name": "hackaday.com",
+    "url": "hackaday.com",
+    "match": "hackaday.com",
+    "config": {
+        "type": "xpath",
+        "xpath": "article",
+        "cleanup": [
+            "ul[@class='sharing']",
+            "ul[@class='share-post']"
+        ]
+    }
+}


### PR DESCRIPTION
All the article doesn't appear in the feed by default, and pictures are
missing.

This recipe fetches the whole article, along with the pictures.

# Rule Submission

Website: hackaday.com

* [X] I have made the rule as simple as possible ( K.I.S.S )
* [X] I have run the rule myself for a period of time to spot any bugs