### PR TITLE
Add missing articleMarker declaration

### DIFF
--- a/init.php
+++ b/init.php
@@ -88,6 +88,7 @@ class Feediron extends Plugin implements IHandler
     if ($config !== false)
     {
       if (version_compare(get_version(), '1.14.0', '<=')){
+        $articleMarker = $this->getMarker($article, $config);
         if (strpos($article['plugin_data'], $articleMarker) !== false)
         {
           return $article;


### PR DESCRIPTION
Was tipped off by a warning in the console:

```
strpos(): Non-string needles will be interpreted as strings in the future.
          Use an explicit chr() call to preserve the current behavior
```