### PR TITLE
add support for summonCthulhu option

### DIFF
--- a/filters/fi_mod_readability/README.md
+++ b/filters/fi_mod_readability/README.md
@@ -20,6 +20,7 @@ Install [Readability.php](https://github.com/andreskrey/readability.php) using [
 		* [prependexcerpt](#prependexcerpt---prependexcerptbool) - `"prependexcerpt":bool`
 		* [prependimage](#prependimage---prependimagebool) - `"prependimage":bool`
 		* [appendimages](#appendimages---appendimagesbool) - `"appendimages":bool`
+		* [summoncthulhu](#summoncthulhu---summoncthulhubool) - `"summoncthulhu":bool`
 	* [cleanup](#cleanup-cleanup-array-of-regex-) - `"cleanup": "/regex str/" / [ "/array of regex str/" ]`
 
 ### Basic Usage:
@@ -127,6 +128,17 @@ Returns all images in article appended after the content.
 "example.com":{
 	"type":"readability",
 	"appendimages":true
+}
+```
+
+#### summoncthulhu - `"summoncthulhu":bool`
+Default value `false`
+
+Remove all `<script>` nodes via regex
+```json
+"example.com":{
+	"type":"readability",
+	"summoncthulhu":true
 }
 ```
 

--- a/filters/fi_mod_readability/init.php
+++ b/filters/fi_mod_readability/init.php
@@ -44,6 +44,14 @@ class fi_mod_readability
             ->setArticleByLine( $config['removebyline'] );
             continue 2;
 
+          case "summoncthulhu":
+            if(!is_bool($value)) continue 2;
+
+            Feediron_Logger::get()->log(Feediron_Logger::LOG_VERBOSE, "Readability.php Summoning Cthulhu");
+            $configuration
+            ->setSummonCthulhu( $config['summoncthulhu'] );
+            continue 2;
+
         }
       }
 


### PR DESCRIPTION
# Bugfix/Enhancement

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?

## Proposed Changes

- Add support for the SummonCthulhu option of readability.php, which cleans up <script> tags.

If a <script> tag contains some embedded HTML, it can mangle the resulting output. Readbility.php provides a workaround for this with the SummonCthulhu option as explained in its [README](https://github.com/andreskrey/readability.php#known-issues)

As seen in the [source](https://github.com/andreskrey/readability.php/blob/84dc70df66978d5f778f31cbc41efcc1c190ea6f/src/Readability.php#L272) this just performs the following:

```php
preg_replace('/<script\b[^>]*>([\s\S]*?)<\/script>/', '', $html);
```

so it is already possible to do by adding that regex to the "cleanup" option, but it would be nice to make it a full-fledged option itself.