### PR TITLE
Fix PHP8 array warning if tidy is not present

### DIFF
--- a/init.php
+++ b/init.php
@@ -598,7 +598,7 @@ class Feediron extends Plugin implements IHandler
       $html = Feediron_Helper::reformat($html, $config['modify']);
     }
     // if we've got Tidy, let's clean it up for output
-    if (function_exists('tidy_parse_string') && $config['tidy'] !== false && $this->charset !== false) {
+    if (function_exists('tidy_parse_string') && $this->array_check($config, 'tidy') && $this->charset !== false) {
       try {
         $tidy = tidy_parse_string($html, array('indent'=>true, 'show-body-only' => true), str_replace(["-", "–"], '', $this->charset));
         $tidy->cleanRepair();


### PR DESCRIPTION
# Bugfix

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?

## Proposed Changes

I updated TTRSS with PHP8 and got a constant warning with the master branch of Feediron. This change fixed it for me.