### PR TITLE
add a check for xpath-query null result

### DIFF
--- a/filters/fi_mod_xpath/init.php
+++ b/filters/fi_mod_xpath/init.php
@@ -92,6 +92,10 @@ class fi_mod_xpath
           $cleanup = '//'.$cleanup;
         }
         $nodelist = $xpath->query($cleanup, $basenode);
+        if (!$nodelist) {
+          Feediron_Logger::get()->log_html(Feediron_Logger::LOG_VERBOSE, "Node not found", $this->getHtmlNode($basenode));
+          continue;
+        }
         foreach ($nodelist as $node)
         {
           if ($node instanceof DOMAttr)


### PR DESCRIPTION
# Enhancement
The method `cleanupNode` uses `$xpath->query` to retrieve a nodelist this can return null and break the following `foreach` resulting in a Warning in the system log like follows:

E_WARNING (2) | plugins.local/feediron/filters/fi_mod_xpath/init.php:95 | foreach() argument must be of type array\|object, bool given 1. plugins.local/feediron/filters/fi_mod_xpath/init.php(95): ttrss_error_handler(2, foreach() argument must be of type array\|object, bool given, plugins.local/feediron/filters/fi_mod_xpath/init.php, 95) 2. plugins.local/feediron/filters/fi_mod_xpath/init.php(41): cleanupNode({DOMXPath}, {DOMElement}, [{"type":"xpath","xpath":"article[contains(@data-article-type,'meldung')]","multipage":{"xpath":"a[contains(@name,'sonderseite.newsticker.bottom.aufeinerseitelesen')]","append":false,"recursive":true},"cleanup":["h1[contains(@class,'clear')]","div[contains(...) 3. plugins.local/feediron/init.php(591): perform_filter(<!DOCTYPE html> <html   lang="de"   data-responsive     data-consentmanagement     class="article-content--scroll-behavior" >   <head>     <script>performance.mark('HEAD Anfang');</script>             <meta charset="utf-8"> <meta name="viewport" content="w..., [{"type":"xpath","xpath":"article[contains(@data-article-type,'meldung')]","multipage":{"xpath":"a[contains(@name,'sonderseite.newsticker.bottom.aufeinerseitelesen')]","append":false,"recursive":true},"cleanup":["h1[contains(@class,'clear')]","div[contains(..., [{"charset":"utf8","link":"https:\/\/www.heise.de\/tests\/Sofa-ntastisch-Die-20-besten-Apps-fuer-Apple-TV-6266028.html?wt_mc=rss.red.ho.ho.atom.beitrag_plus.beitrag_plus"}) 4. plugins.local/feediron/init.php(225): processArticle(<!DOCTYPE html> <html   lang="de"   data-responsive     data-consentmanagement     class="article-content--scroll-behavior" >   <head>     <script>performance.mark('HEAD Anfang');</script>             <meta charset="utf-8"> <meta name="viewport" content="w..., [{"type":"xpath","xpath":"article[contains(@data-article-type,'meldung')]","multipage":{"xpath":"a[contains(@name,'sonderseite.newsticker.bottom.aufeinerseitelesen')]","append":false,"recursive":true},"cleanup":["h1[contains(@class,'clear')]","div[contains(..., https://www.heise.de/tests/Sofa-ntastisch-Die-20-besten-Apps-fuer-Apple-TV-6266028.html?wt_mc=rss.red.ho.ho.atom.beitrag_plus.beitrag_plus) 5. plugins.local/feediron/init.php(102): getNewContent(https://www.heise.de/tests/Sofa-ntastisch-Die-20-besten-Apps-fuer-Apple-TV-6266028.html?wt_mc=rss.red.ho.ho.atom.beitrag_plus.beitrag_plus, [{"type":"xpath","xpath":"article[contains(@data-article-type,'meldung')]","multipage":{"xpath":"a[contains(@name,'sonderseite.newsticker.bottom.aufeinerseitelesen')]","append":false,"recursive":true},"cleanup":["h1[contains(@class,'clear')]","div[contains(...) 6. classes/pluginhost.php(342): hook_article_filter([{"owner_uid":2,"guid":"2,http:\/\/heise.de\/-6266028","guid_hashed":"{\"ver\":2,\"uid\":2,\"hash\":\"SHA1:b4e65a44a846608ccc7dbfe61a83a203c057e61c\"}","title":"heise+ \| Sofa-ntastisch: Die 20 besten Apps f\u00fcr Apple TV","content":"<!DOCTYPE html PUBLIC ...) 7. classes/rssutils.php(803): chain_hooks_callback(hook_article_filter, {Closure}, [{"owner_uid":2,"guid":"2,http:\/\/heise.de\/-6266028","guid_hashed":"{\"ver\":2,\"uid\":2,\"hash\":\"SHA1:b4e65a44a846608ccc7dbfe61a83a203c057e61c\"}","title":"heise+ \| Sofa-ntastisch: Die 20 besten Apps f\u00fcr Apple TV","content":"<!DOCTYPE html PUBLIC ...) 8. update.php(232): update_rss_feed(113, 1)
-- | -- | --

# Proposal

Check the `nodelist` and add a `Feediron_Logger` entry instead.