### PR TITLE
Dev

### DIFF
--- a/filters/fi_mod_tags_xpath/init.php
+++ b/filters/fi_mod_tags_xpath/init.php
@@ -5,6 +5,7 @@ class fi_mod_tags_xpath
 
   public function get_tags($html, $config, $settings )
   {
+    $tags = array(); // initialize tags array
     if(!( array_key_exists('xpath', $config) && is_array($config['xpath']) )){
       $xpaths = array($config['xpath']);
     }else{

--- a/init.php
+++ b/init.php
@@ -460,7 +460,8 @@ class Feediron extends Plugin implements IHandler
       /* If recursive mode is active fetch links from newly fetched link */
       if(isset($config['multipage']['recursive']) && $config['multipage']['recursive'] && !($counter == ($maxpages-1)) )
       {
-        $links =  $this->fetch_links($lnk, $config, $counter, $maxpages, array($links, $link));
+        array_push($links, $link); // Add $link to $links array
+        $links =  $this->fetch_links($lnk, $config, $counter, $maxpages, $links);
       }
     }
     if(isset($config['multipage']['append']) && $config['multipage']['append'])

--- a/init.php
+++ b/init.php
@@ -212,6 +212,8 @@ class Feediron extends Plugin implements IHandler
 
     if( array_key_exists('replace-tags', $config)){
       $NewContent['replace-tags'] = $config['replace-tags'];
+    } else {
+      $NewContent['replace-tags'] = False;
     }
 
     foreach($links as $lnk)


### PR DESCRIPTION
Fix warnings:
1. Undefined variable $tags - explicit initialize tags array
2. Undefined array key "replace-tags" - $NewContent['replace-tags'] should be explicitly set false 
3. Multipage fix - On multipage parsing nested seenlinks arrays caused errors.