### PR TITLE
Fix name of op for pref tab

### DIFF
--- a/preftab/fi_pref_tab.php
+++ b/preftab/fi_pref_tab.php
@@ -107,7 +107,7 @@ class Feediron_PrefTab{
 	}
 	private static function get_form_start($method){
 		$form = '<form dojoType="dijit.form.Form">';
-		$form .='<input dojoType="dijit.form.TextBox" style="display : none" name="op" value="pluginhandler">';
+		$form .='<input dojoType="dijit.form.TextBox" style="display : none" name="op" value="PluginHandler">';
 		$form .= '<input dojoType="dijit.form.TextBox" style="display : none" name="method" value="'.$method.'">';
 		$form .= '<input dojoType="dijit.form.TextBox" style="display : none" name="plugin" value="feediron">';
 		return $form;


### PR DESCRIPTION
Not sure if this changed with newer ttrss or it's because of some other factor, but the PluginHandler class name is case sensitive and needs to be corrected or you get E_UNKNOWN_METHOD when trying to do anything at all with the pref tab.

Please answer the following questions for yourself before submitting a pull request. **YOU MAY DELETE UNUSED SECTIONS.**

NOTICE!!!

All rule submissions should be done in the https://github.com/feediron/feediron-recipes repository.

# Bugfix/Enhancement

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully ran tests with your changes locally?

Fixes #

## Proposed Changes

-
-
-
