### PR TITLE
Feature/replace with url

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,20 @@ Result: `Tag1, Tag2, Tag3`
 
 Reformat is an array of formatting rules for the url of the full article. The rules are applied before the full article is fetched. Where as Modify is an array of formatting rules for article using the same options.
 
+In both replace cases ([replace (regex)](#replace---replacestr) and [replace (replace)](#replace---replacestr---array-of-str-)), it is possible to use replace modifiers. Following variables might be available in both options:
+
+ - `{$link}` = Link to the article.
+ - `{$scheme}` = Scheme like http / https
+ - `{$host}` = Host of the articles URL
+ - `{$port}` = Port of the articles URL
+ - `{$user}` = User if one was given in articles URL (unusual) 
+ - `{$pass}` = Password if one was given in articles URL (unusual)
+ - `{$path}` = Path after host/domain
+ - `{$query}` = everything after article url "?"
+ - `{$fragment}` = Fragment e.g. anchor followed by #
+
+If a variable is specified in `replace` option, but not known, it will not be replaced.
+
 ### regex - `"type":"regex"`
 
 regex takes a regex in an option called pattern and the replacement in replace. For details see [preg_replace](http://www.php.net/manual/de/function.preg-replace.php) in the PHP documentation.

--- a/bin/fi_helper.php
+++ b/bin/fi_helper.php
@@ -30,14 +30,20 @@ class Feediron_Helper
 
   }
 
-  public static function replaceStringVariableOptions(string $replaceString, array $replaceVars) {
-    return str_replace(
-      array_map(function($k) {
-          return '{$'.$k.'}';
-      }, array_keys($replaceVars)),
-      array_values($replaceVars),
-      $replaceString
-    );
+  public static function replaceStringVariableOptions(string|array $replaceString, array $replaceVars) {
+    if (is_array($replaceString)) {
+      return array_map(function(string|array $element) use ($replaceVars) {
+        return self::replaceStringVariableOptions($element, $replaceVars);
+      }, $replaceString);
+    } else {
+      return str_replace(
+        array_map(function($k) {
+            return '{$'.$k.'}';
+        }, array_keys($replaceVars)),
+        array_values($replaceVars),
+        $replaceString
+      );
+    }
   }
 
   // reformat a string with given options

--- a/init.php
+++ b/init.php
@@ -196,7 +196,7 @@ class Feediron extends Plugin implements IHandler
     $link = trim($url);
     if($this->array_check($config, 'reformat'))
     {
-      $link = Feediron_Helper::reformat($link, $config['reformat']);
+      $link = Feediron_Helper::reformat($link, $config['reformat'], $link);
       Feediron_Logger::get()->log(Feediron_Logger::LOG_TTRSS, "Reformated url: ".$link);
     }
     return $link;
@@ -221,7 +221,7 @@ class Feediron extends Plugin implements IHandler
       $html = $this->getArticleContent($lnk, $config);
       if( isset( $config['tags'] ) )
       {
-        $NewContent['tags'] = $this->getArticleTags($html, $config['tags']);
+        $NewContent['tags'] = $this->getArticleTags($html, $config['tags'], $lnk);
       }
       Feediron_Logger::get()->log_html(Feediron_Logger::LOG_TEST, "Original Source ".$lnk.":", $html);
       $html = $this->processArticle($html, $config, $lnk);
@@ -360,7 +360,7 @@ class Feediron extends Plugin implements IHandler
     return $html;
   }
 
-  function getArticleTags( $html, $config )
+  function getArticleTags( $html, $config, string $articleLink )
   {
     // Build settings array
     $settings = array( "charset" => $this->charset );
@@ -396,7 +396,7 @@ class Feediron extends Plugin implements IHandler
       // If set perform modify
       if($this->array_check($config, 'modify'))
       {
-        $tag = Feediron_Helper::reformat($tag, $config['modify']);
+        $tag = Feediron_Helper::reformat($tag, $config['modify'], $articleLink);
       }
       // Strip tags of html and ensure plain text
       $tags[$key] = trim( preg_replace('/\s+/', ' ', strip_tags( $tag ) ) );
@@ -598,7 +598,7 @@ class Feediron extends Plugin implements IHandler
 
     if($this->array_check($config, 'modify'))
     {
-      $html = Feediron_Helper::reformat($html, $config['modify']);
+      $html = Feediron_Helper::reformat($html, $config['modify'], $link);
     }
     // if we've got Tidy, let's clean it up for output
     if (function_exists('tidy_parse_string') && $this->array_check($config, 'tidy') && $this->charset !== false) {


### PR DESCRIPTION
Please answer the following questions for yourself before submitting a pull request. **YOU MAY DELETE UNUSED SECTIONS.**

# Bugfix/Enhancement

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?

Fixes feediron/ttrss_plugin-feediron#194

## Proposed Changes

As per the linked ticket, it was requested to have the ability to use the articles link or components of the articles link for in modify option.

This MR added the corresponding option.

Tested with following modify rules:
```json
    "modify": [
        {
            "type": "replace",
            "search": [
                "<h2>",
                "<\/h2>"
            ],
            "replace": [
                "<h2>",
                " (Link: {$link} \/ {$host})<\/h2>"
            ]
        },
        {
            "type": "replace",
            "search": "Begeisterung",
            "replace": "<strong>(Link: {$link} \/ {$host})<\/strong>"
        },
        {
            "type": "regex",
            "pattern": "\/(.*)Mitte der ([0-9]+)er Jahre(.*)\/",
            "replace": "$1<strong>(Host: {$host}; Jahrhundert: $2)<\/strong>$3"
        }
    ]
```

The possible options are described in the `README.md` file.

Was this the intended way to go for @dugite-code ?

Best regards,
monofox
